### PR TITLE
Feature/add jacoco report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ addons:
   artifacts:
     debug: true
     paths:
-      - ./build/reports/tests/test
+      - ./build/reports/
     target_paths: $TRAVIS_BUILD_NUMBER
     working_dir: WORKING_DIR
     bucket: inte-project

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ cache:
     - $HOME/.gradle/wrapper/
     
    # Custom gradle build command to generate jaCoCo coverage
- script:
+script:
     - gradle check
     - gradle jacocoTestReport
     

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
     
+   # Custom gradle build command to generate jaCoCo coverage
+ script:
+    - gradle build jacocoTestReport
     
   # uploads testresults and coverage to s3 bucket, access keys and s3 bucket
   # name is specified in travis repo settings

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ cache:
     
    # Custom gradle build command to generate jaCoCo coverage
  script:
-    - gradle build jacocoTestReport
+    - gradle check
+    - gradle jacocoTestReport
     
   # uploads testresults and coverage to s3 bucket, access keys and s3 bucket
   # name is specified in travis repo settings

--- a/build.gradle
+++ b/build.gradle
@@ -32,3 +32,13 @@ dependencies {
     testCompile 'junit:junit:4.12'
 }
 
+// Tell Gradle to generate jaCoCo reports
+// get Gradle to generate report by running "gradle build jacocoTestReport"
+
+	jacocoTestReport {
+	    group = "Reporting"
+	    description = "Generate jaCoCo coverage report"
+	    additionalSourceDirs = files(sourceSets.main.allJava.srcDirs)
+	}
+
+


### PR DESCRIPTION
Gradle is now creating coverage reports. Travis ci is uploading them to github. Note that reports are only created when running "gradle jacocoTestReports"
