### PR TITLE
Feature/fix touch creates touchfile

### DIFF
--- a/src/main/java/org/pucko/commands/Touch.java
+++ b/src/main/java/org/pucko/commands/Touch.java
@@ -11,6 +11,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.List;
 
 
 import org.pucko.core.InputHandler;
@@ -27,7 +28,7 @@ public class Touch extends Command {
     @Override
     public boolean execute() {
 
-        ArrayList<String> args = getArgs();
+        List<String> args = getArgs().subList(1, getArgs().size());
 
         for (String s : args) {
 

--- a/src/test/java/org/pucko/commands/TouchTest.java
+++ b/src/test/java/org/pucko/commands/TouchTest.java
@@ -55,7 +55,7 @@ public class TouchTest {
         setArgs(commandUtils, VALID_TOUCH_COMMAND, VALID_FILENAME);
         Touch t = new Touch(commandUtils);
 
-        List<Path> filePathArray = createPathArray(commandUtils.getArgs()).subList(1, commandUtils.getArgs().size());
+        List<Path> filePathArray = createPathArray(commandUtils.getArgs());
         t.runCommand();
         assertFiles(filePathArray);
     }
@@ -82,6 +82,21 @@ public class TouchTest {
         ArrayList<Path> filePathArray = createPathArray(commandUtils.getArgs());
         t.runCommand();
         assertFiles(filePathArray);
+    }
+
+    @Test
+    public void testDoesNotCreateTouchFile() { //Makes sure the command does not create a file from the command name
+        when(commandUtils.getWorkingDirectory()).thenReturn(folderPath);
+
+        setArgs(commandUtils, VALID_TOUCH_COMMAND, VALID_FILENAME);
+        Touch t = new Touch(commandUtils);
+
+        List<Path> filePathArray = createPathArray(commandUtils.getArgs()).subList(1, commandUtils.getArgs().size());
+        t.runCommand();
+
+        Path p = folderPath.resolve(VALID_TOUCH_COMMAND);
+
+        assertFalse("File: " + p.toString(), new File(p.toString()).isFile());
     }
 
 
@@ -207,7 +222,9 @@ public class TouchTest {
     }
 
     private void assertFiles(List<Path> filePathArray) {
-        for (Path p : filePathArray) {
+        List<Path> filePaths = filePathArray.subList(1, commandUtils.getArgs().size());
+
+        for (Path p : filePaths) {
             assertTrue("File: " + p.toString(), new File(p.toString()).isFile());
         }
 


### PR DESCRIPTION
Touch skapade alltid en fil med namnet touch eftersom den gick igenom hela argumentlistan från getArgs() och gjorde filer av den. I getArgs() finns ju också själva kommandonamnet med.
